### PR TITLE
Hide Wallet dropdown when network is not selected

### DIFF
--- a/src/components/WalletConnect.vue
+++ b/src/components/WalletConnect.vue
@@ -24,7 +24,7 @@
 				</a-dropdown>
 			</a-col>
 
-			<a-col>
+			<a-col v-if="selectedNetwork !== NetworkTypes.NONE">
 				<a-dropdown>
 					<template #overlay>
 						<a-menu @click="handleWalletConnect">


### PR DESCRIPTION
Hide Wallet dropdown when network is not selected
Task: https://www.pivotaltracker.com/story/show/182220027